### PR TITLE
fix correct closing on timeout

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -390,7 +390,6 @@ func (pom *partitionOffsetManager) closeLoop(done chan none) bool {
 		case <-time.After(time.Second * 5):
 			Logger.Printf("client/offsetManager offset commit timeout on shutdown! Not commited group=%s topic=%s partition=%d offset=%d\n", pom.parent.group, pom.topic, pom.partition, pom.offset)
 			pom.clean.Signal()
-			close(pom.dying)
 			timeouted = true
 		case <-done:
 			return timeouted
@@ -411,6 +410,7 @@ func (pom *partitionOffsetManager) AsyncClose() {
 			}()
 			timeouted = pom.closeLoop(done)
 		}
+		close(pom.dying)
 	}()
 }
 

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -249,6 +249,7 @@ func (pom *partitionOffsetManager) mainLoop() {
 				select {
 				case <-pom.rebalance:
 				case pom.broker.updateSubscriptions <- pom:
+				case <-time.After(time.Second * 5):
 				}
 				pom.parent.unrefBrokerOffsetManager(pom.broker)
 			}
@@ -382,25 +383,34 @@ func (pom *partitionOffsetManager) NextOffset() (int64, string) {
 	return pom.parent.conf.Consumer.Offsets.Initial, ""
 }
 
+func (pom *partitionOffsetManager) closeLoop(done chan none) bool {
+	timeouted := false
+	for {
+		select {
+		case <-time.After(time.Second * 5):
+			Logger.Printf("client/offsetManager offset commit timeout on shutdown! Not commited group=%s topic=%s partition=%d offset=%d\n", pom.parent.group, pom.topic, pom.partition, pom.offset)
+			pom.clean.Signal()
+			close(pom.dying)
+			timeouted = true
+		case <-done:
+			return timeouted
+		}
+	}
+}
+
 func (pom *partitionOffsetManager) AsyncClose() {
 	go func() {
 		pom.lock.Lock()
 		defer pom.lock.Unlock()
-		for pom.dirty {
+		timeouted := false
+		for pom.dirty && !timeouted {
 			done := make(chan none)
 			go func() {
 				pom.clean.Wait()
 				close(done)
 			}()
-			select {
-			case <-time.After(time.Second * 5):
-				Logger.Printf("client/offsetManager offset commit timeout on shutdown! Not commited group=%s topic=%s partition=%d offset=%d\n", pom.parent.group, pom.topic, pom.partition, pom.offset)
-				goto timeout
-			case <-done:
-			}
+			timeouted = pom.closeLoop(done)
 		}
-	timeout:
-		close(pom.dying)
 	}()
 }
 


### PR DESCRIPTION
Why:

- There was bug in code that can be triggered using the following test
- Bug:  When the clean waits it changes the state of the mutex.
- So we need to signal it anyway to return the mutex to the previous stage.

Otherwise, we will call Unlock on already unlocked mutex 