### PR TITLE
fix NewTopicConsumer init

### DIFF
--- a/topic_consumer.go
+++ b/topic_consumer.go
@@ -53,7 +53,10 @@ func NewTopicConsumer(client Client, topic string, offsets map[int32]int64, offs
 	}
 
 	for _, partition := range partitions {
-		consumer.initPartition(partition, offsets[partition])
+		err = consumer.initPartition(partition, offsets[partition])
+		if err != nil {
+			return nil, fmt.Errorf("Unable to init partition  %v: %v", partition, err)
+		}
 	}
 
 	return consumer, nil

--- a/topic_consumer.go
+++ b/topic_consumer.go
@@ -87,7 +87,7 @@ func (sc *topicConsumer) initPartition(partition int32, offset int64) error {
 	}
 
 	if newestOffset < resumeFrom {
-		Logger.Printf("given offset for %v/%v is unavailable (newest < resume_from). Auto correcting to oldest available offset: resume_from=%v newest=%v", sc.topic, partition, resumeFrom, newestOffset)
+		Logger.Printf("given offset for %v/%v is unavailable (newest < resume_from). Auto correcting to newest available offset: resume_from=%v newest=%v", sc.topic, partition, resumeFrom, newestOffset)
 		resumeFrom = newestOffset
 	}
 


### PR DESCRIPTION
The reason of the bug - when we start with new topic in bloom filter, the offsets are 0, and probably they do not exist already in this topic. So NewTopicConsumer should fail with error